### PR TITLE
Fix docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,36 +33,15 @@ composer install
 ```
 8. Database import.
 ```
-# Go the mySQL container:
-sudo docker exec -it mysql bash
-
-# Login using password defined in yml file:
-mysql -u root -p
-
-# Check Databases:
-show databases;
-
-# If database mentioned in yml file is not creaated, create the database:
-create database symcom_minified_db;
-
-# Exit the mysql bash and container:
-exit
-
-# Import the SQL provided in the repo root to Docker temp.
-sudo docker cp /location-of-cloned-root-folder/new_database_synonym_test.sql mysql:/tmp/
-
-# Access mySQL container again:
-sudo docker exec -it mysql bash
-
-# Import the SQL to newly created database symcom_minified_db:
-mysql -u root -p symcom_minified_db < /tmp/new_database_synonym_test.sql
-
-# Check to verify the tables inside the database going to mySQL bash
-mysql -u root -p
-use database symcom_minified_db;
-show all tables;
-
+cat new_database_synonym_test.sql | docker exec -i mysql mysql -u root -proot symcom_minified_db
 ```
+
+Afterwards, check to verify the tables inside the database going to MySQL bash
+```
+docker exec -it mysql mysql -u root -proot symcom_minified_db
+show tables;
+```
+
 9. If in any case, the database and apache configurations are chaneged, make edits in `config/routes.php`.
 ```
 Change PHP variable $absoluteUrl.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker exec -it mysql mysql -u root -proot symcom_minified_db
 show tables;
 ```
 
-9. If in any case, the database and apache configurations are chaneged, make edits in `config/routes.php`.
+9. (Optional) If in any case, the database and apache configurations are changed, make edits in `config/routes.php`.
 ```
 Change PHP variable $absoluteUrl.
 Change $dbHost, $dbUsername, $dbPassword, $dbName.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ In order to get the program running, the repo along with database is needed.
 2. Check Docker.
 ```
 docker --version
-docker-compose --version
 ```
 3. Change the ownership of the cloned directory.
 ```
@@ -15,8 +14,8 @@ sudo chown -R $USER:$USER location-directory-location/symcom-synonym-tool
 ```
 4. Build Docker Images and Run.
 ```
-sudo docker-compose build
-sudo docker-compose up -d
+sudo docker compose build
+sudo docker compose up -d
 ```
 5. Check if contianers are running. If errors are encountered for already used ports. Deactivate the ports.
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,15 +16,17 @@ services:
     # environment:
     #   - APACHE_DOCUMENT_ROOT=/var/www/html/symcom-synonym-tool
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: mysql
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: symcom_minified_db
+      MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
     ports:
       - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
+      - ./my.cnf:/etc/my.cnf
 
 volumes:
   db_data:

--- a/my.cnf
+++ b/my.cnf
@@ -1,0 +1,36 @@
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/8.0/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+
+# Remove leading # to revert to previous value for default_authentication_plugin,
+# this will increase compatibility with older clients. For background, see:
+# https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
+default-authentication-plugin=mysql_native_password
+skip-host-cache
+skip-name-resolve
+datadir=/var/lib/mysql
+socket=/var/run/mysqld/mysqld.sock
+secure-file-priv=/var/lib/mysql-files
+user=mysql
+
+pid-file=/var/run/mysqld/mysqld.pid
+[client]
+socket=/var/run/mysqld/mysqld.sock
+
+!includedir /etc/mysql/conf.d/


### PR DESCRIPTION
- Fix docker compose deprecated call
- Fix overly complicated DB setup
- Make clear that step 9 is optional
- Update to MySQL 8.0 and therefore set `default-authentication-plugin=mysql_native_password`  in my.cnf

Please not that if you want to stop an existing installation and try a newer / older database, you'll need to call `docker compose down -v`.  (`-v to remove the volumes).